### PR TITLE
Install the most current version of `fish`

### DIFF
--- a/Dockerfile.apt
+++ b/Dockerfile.apt
@@ -55,6 +55,8 @@ RUN apt-get update && apt-get install -y --allow-downgrades --allow-remove-essen
   tmux \
   xclip \
   zsh \
+  && echo 'deb http://download.opensuse.org/repositories/shells:/fish/Debian_9.0/ /' > /etc/apt/sources.list.d/shells:fish.list \
+  && apt-get update && apt-get install fish \
   && apt-get clean \
   && rm -rf /var/lib/apt/lists/
 

--- a/Dockerfile.apt
+++ b/Dockerfile.apt
@@ -56,7 +56,7 @@ RUN apt-get update && apt-get install -y --allow-downgrades --allow-remove-essen
   xclip \
   zsh \
   && echo 'deb http://download.opensuse.org/repositories/shells:/fish/Debian_9.0/ /' > /etc/apt/sources.list.d/shells:fish.list \
-  && apt-get update && apt-get install fish \
+  && apt-get update && apt-get install -y --allow-downgrades --allow-remove-essential --allow-change-held-packages --allow-unauthenticated --no-install-recommends --no-upgrade fish \
   && apt-get clean \
   && rm -rf /var/lib/apt/lists/
 


### PR DESCRIPTION
This is a minor change. It follows instructions on the [`fish-shell`](https://github.com/fish-shell/fish-shell) repo for installing on Debian, which refer to [openSUSE Build Service](https://software.opensuse.org/download.html?project=shells%3Afish&package=fish).  That service gives the following instructions:

>For Debian 9.0 run the following as root:
```
echo 'deb http://download.opensuse.org/repositories/shells:/fish/Debian_9.0/ /' > /etc/apt/sources.list.d/shells:fish.list
apt-get update
apt-get install fish
```
>You can add the repository key to apt. Keep in mind that the owner of the key may distribute updates, packages and repositories that your system will trust (more information). To add the key, run:
```
wget -nv https://download.opensuse.org/repositories/shells:fish/Debian_9.0/Release.key -O Release.key
apt-key add - < Release.key
apt-get update
```

I added the first lines of code, but not the second.

I also tested out installing `fish` 3.0.2 on the currently running container, and it seems to work fine.

Let me know if I followed poor practice for Dockerfiles or made some other mistake. :)