### PR TITLE
Run cron with s6 supervisor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 .Ruserdata
 access.log
 libs.txt
+cache

--- a/Dockerfile.server
+++ b/Dockerfile.server
@@ -66,6 +66,9 @@ RUN mkdir -p /var/run/sshd \
   && echo '#!/bin/bash \n service ssh stop' > /etc/services.d/sshd/finish \
   && sed -i 's/PermitRootLogin no/PermitRootLogin yes/' /etc/ssh/sshd_config \
   && echo "PasswordAuthentication yes" >> /etc/ssh/sshd_config \
-  && echo "AllowGroups ssh-users" >> /etc/ssh/sshd_config
+  && echo "AllowGroups ssh-users" >> /etc/ssh/sshd_config \
+## Also setup cron \
+  && mkdir -p /etc/services.d/cron \
+  && echo '#!/usr/bin/with-contenv sh\ntouch /etc/crontab /etc/cron.*/*\nexec cron -f' > /etc/services.d/cron/run
 
 EXPOSE 22 8787 3838

--- a/Dockerfile.server
+++ b/Dockerfile.server
@@ -58,7 +58,7 @@ RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime \
   && echo $TZ > /etc/timezone \
   && dpkg-reconfigure --frontend noninteractive tzdata
 
-## Setup SSH. s6 supervisor already installed for RStudio, so
+## Setup SSH and cron. s6 supervisor already installed for RStudio, so
 ## just create the run and finish scripts
 RUN mkdir -p /var/run/sshd \
   && mkdir -p /etc/services.d/sshd \
@@ -67,7 +67,6 @@ RUN mkdir -p /var/run/sshd \
   && sed -i 's/PermitRootLogin no/PermitRootLogin yes/' /etc/ssh/sshd_config \
   && echo "PasswordAuthentication yes" >> /etc/ssh/sshd_config \
   && echo "AllowGroups ssh-users" >> /etc/ssh/sshd_config \
-## Also setup cron \
   && mkdir -p /etc/services.d/cron \
   && echo '#!/usr/bin/with-contenv sh\ntouch /etc/crontab /etc/cron.*/*\nexec cron -f' > /etc/services.d/cron/run
 

--- a/build-and-push.sh
+++ b/build-and-push.sh
@@ -6,6 +6,7 @@ set -x
 for tag in apt rcppeigen rstan inla rpkg server gpu
 do
   image=ecohealthalliance/reservoir:$tag
+  docker pull $image
   docker build -q -f Dockerfile.$tag --cache-from $image -t $image .
   docker push $image
 done

--- a/build-and-push.sh
+++ b/build-and-push.sh
@@ -6,7 +6,7 @@ set -x
 for tag in apt rcppeigen rstan inla rpkg server gpu
 do
   image=ecohealthalliance/reservoir:$tag
-  docker pull $image
-  docker build -q -f Dockerfile.$tag --cache-from $image -t $image .
+  time docker pull $image
+  time docker build -q -f Dockerfile.$tag --cache-from $image -t $image .
   docker push $image
 done

--- a/build.sh
+++ b/build.sh
@@ -6,5 +6,6 @@ set -x
 for tag in apt rcppeigen rstan inla rpkg server gpu
 do
   image=ecohealthalliance/reservoir:$tag
+  docker pull $image
   docker build -q -f Dockerfile.$tag --cache-from $image -t $image .
 done

--- a/build.sh
+++ b/build.sh
@@ -6,6 +6,6 @@ set -x
 for tag in apt rcppeigen rstan inla rpkg server gpu
 do
   image=ecohealthalliance/reservoir:$tag
-  docker pull $image
-  docker build -q -f Dockerfile.$tag --cache-from $image -t $image .
+  time docker pull $image
+  time docker build -q -f Dockerfile.$tag --cache-from $image -t $image .
 done

--- a/config/rsession.conf
+++ b/config/rsession.conf
@@ -3,8 +3,8 @@
 # By default, do not save use workspace
 session-save-action-default=no
 
-# Sleep sessions after 30 minute timeouts
-session-timeout-minutes=30
+# Sleep sessions after 12 hour timeouts
+session-timeout-minutes=720
 
 #Display disk usage limits
 #limit-xfs-disk-quota=1


### PR DESCRIPTION
This adds an init script to the reservoir image for cron, hopefully addressing https://github.com/ecohealthalliance/eha-servers/issues/40 .  It follows https://esc.sh/blog/cron-jobs-in-docker/, which indicates that cron has an issue with Docker hard links and this should fix it. 

Not sure if anything has to be adjusted in the ansible start-up scripts with this.